### PR TITLE
Add Django CORS header package and enable it in settings

### DIFF
--- a/arbisoft_sessions_portal/settings/base.py
+++ b/arbisoft_sessions_portal/settings/base.py
@@ -46,6 +46,7 @@ REST_FRAMEWORK = {
 # Application definition
 
 INSTALLED_APPS = [
+    'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -59,6 +60,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -67,6 +69,9 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = True
 
 ROOT_URLCONF = 'arbisoft_sessions_portal.urls'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.8.1
 certifi==2024.8.30
 charset-normalizer==3.4.0
 Django==4.2.16
+django-cors-headers==4.6.0
 django-filter==24.3
 djangorestframework==3.15.2
 djangorestframework-simplejwt==5.3.1


### PR DESCRIPTION
## Description

- Added `django-cors-headers==4.6.0` in requirements
- Updated `INSTALLED_APPS` and `MIDDLEWARE` with corsheaders
- Set `CORS_ORIGIN_ALLOW_ALL` and `CORS_ALLOW_CREDENTIALS` to True

Link to the associated Taiga ticket: https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/38

