### PR TITLE
Add video duration in events list api

### DIFF
--- a/events/v1/serializers.py
+++ b/events/v1/serializers.py
@@ -21,13 +21,14 @@ class EventSerializer(serializers.ModelSerializer):
     publisher = PublisherSerializer(source='creator')
     tags = serializers.SerializerMethodField()
     thumbnail = serializers.SerializerMethodField()
+    video_duration = serializers.SerializerMethodField()
 
     class Meta:
         model = Event
         fields = (
             'id', 'title', 'description', 'publisher', 'event_time',
             'event_type', 'status', 'workstream_id', 'is_featured', 'tags',
-            'thumbnail'
+            'thumbnail', 'video_duration'
         )
 
     @staticmethod
@@ -40,6 +41,12 @@ class EventSerializer(serializers.ModelSerializer):
         """ Get thumbnail of an event if available """
         video = event.videos.first()
         return video.thumbnail.url if video and video.thumbnail else ''
+
+    @staticmethod
+    def get_video_duration(event):
+        """ Get duration of video if available """
+        video = event.videos.first()
+        return video.duration if video and video.duration else None
 
 
 class VideoAssetSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Description

- Updated `api/v1/events/all/` API to add duration of the video associated with the event
- Video duration is either an integer value or None 

Link to the associated Taiga ticket: https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/91

## Considerations

- Ensure that the changes are merged only after receiving at least two reviews.
- Take performance issues into account.
- Verify that database migrations are backwards-compatible.

## Post-review

Combine commits into distinct sets of changes.
