### PR TITLE
Enable ordering and custom pagination on Event List API

### DIFF
--- a/events/v1/filters.py
+++ b/events/v1/filters.py
@@ -10,6 +10,7 @@ class EventFilter(django_filters.rest_framework.FilterSet):
 
     search = django_filters.CharFilter(method='filter_search')
     tag = django_filters.CharFilter(method='filter_tag')
+    ordering = django_filters.OrderingFilter(fields=("event_type", "is_featured", "status"))
 
     class Meta:
         model = Event

--- a/events/v1/pagination.py
+++ b/events/v1/pagination.py
@@ -1,0 +1,8 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class CustomPageNumberPagination(PageNumberPagination):
+    """ Custom pagination class to set page size"""
+    page_size = 10
+    page_size_query_param = 'page_size'
+    max_page_size = 100

--- a/events/v1/views.py
+++ b/events/v1/views.py
@@ -1,7 +1,6 @@
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.generics import ListAPIView, RetrieveAPIView
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -9,6 +8,7 @@ from django.shortcuts import get_object_or_404
 
 from events.models import Event, Tag, VideoAsset
 from events.v1.filters import EventFilter
+from events.v1.pagination import CustomPageNumberPagination
 from events.v1.serializers import EventSerializer, TagListSerializer, VideoAssetSerializer
 
 
@@ -44,9 +44,9 @@ class EventTypeListView(APIView):
 class EventsListView(ListAPIView):
     """ View for listing the events """
 
-    queryset = Event.objects.all()
+    queryset = Event.objects.all().order_by("-status")
     serializer_class = EventSerializer
-    pagination_class = PageNumberPagination
+    pagination_class = CustomPageNumberPagination
     filterset_class = EventFilter
 
 


### PR DESCRIPTION
## Description

- Introduced dynamic pagination for the `EventsListView` API to allow users to customize the number of items per page using the `page_size` query parameter.
- Fixed the `UnorderedObjectListWarning` by adding a default ordering (`-status`) to the queryset.
- Updated EventFilter class to enable ordering on `event_type`, `status`, `is_featured`.

Link to the associated Taiga ticket: https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/92

## Considerations

- Ensure that the changes are merged only after receiving at least two reviews.
- Take performance issues into account.
- Verify that database migrations are backwards-compatible.

## Post-review

Combine commits into distinct sets of changes.
