### PR TITLE
Remove workstream_id from event admin and serializer

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -47,7 +47,7 @@ class EventAdmin(admin.ModelAdmin):
     fieldsets = (
         (None, {
             'fields': ('creator', 'title', 'description', 'event_time',
-                       'event_type', 'status', 'workstream_id', 'is_featured',
+                       'event_type', 'status', 'is_featured',
                        'tags', 'playlists')
         }),
     )

--- a/events/v1/serializers.py
+++ b/events/v1/serializers.py
@@ -41,7 +41,7 @@ class EventSerializer(serializers.ModelSerializer):
         model = Event
         fields = (
             'id', 'title', 'description', 'publisher', 'event_time',
-            'event_type', 'status', 'workstream_id', 'is_featured', 'tags',
+            'event_type', 'status', 'is_featured', 'tags',
             'thumbnail', 'video_duration', 'presenters', 'playlists'
         )
 


### PR DESCRIPTION
## Description

- Removed workstream_id from Event admin and serializer

Link to the associated Taiga ticket: https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/123

## Considerations

- Ensure that the changes are merged only after receiving at least two reviews.
- Take performance issues into account.
- Verify that database migrations are backwards-compatible.

## Post-review

Combine commits into distinct sets of changes.
