### PR TITLE
🪜  Update EventPresenterForm Dropdown to be User Autocomplete field

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -26,6 +26,7 @@ class EventPresenterInline(admin.StackedInline):
     model = EventPresenter
     form = EventPresenterForm
     extra = 1
+    autocomplete_fields = ('user',)
 
 
 class EventAdmin(admin.ModelAdmin):

--- a/events/forms.py
+++ b/events/forms.py
@@ -51,15 +51,7 @@ class VideoAssetForm(forms.ModelForm):
 
 
 class EventPresenterForm(forms.ModelForm):
-    """ Custom form to show first_name and last_name in the dropdown """
-    user = forms.ModelChoiceField(
-        queryset=User.objects.all().order_by("first_name", "last_name"),
-        label="Presenter"
-    )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["user"].label_from_instance = lambda obj: f"{obj.first_name} {obj.last_name}"
+    """ Custom form for EventPresenter Model """
 
     class Meta:
         model = EventPresenter

--- a/users/admin.py
+++ b/users/admin.py
@@ -16,6 +16,7 @@ class CustomUserAdmin(UserAdmin):
             "fields": ("username", "email", "first_name", "last_name", "password1", "password2"),
         }),
     )
+    search_fields = ['first_name', 'last_name', 'email']
 
 
 admin.site.unregister(User)


### PR DESCRIPTION
## Description

- Updated EventPresenterForm drop down to be autocomplete user field. The user should be searchable by first_name, last_name and email

Link to the associated Taiga ticket: https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/156

## Considerations

- Ensure that the changes are merged only after receiving at least two reviews.
- Take performance issues into account.
- Verify that database migrations are backwards-compatible.

## Post-review

Combine commits into distinct sets of changes.
