### PR TITLE
🏷️  Add Optional linked_to_events Filter for Tags and Playlists APIs

### DIFF
--- a/events/tests/test_apis.py
+++ b/events/tests/test_apis.py
@@ -62,7 +62,7 @@ class TestEventsAPI:
         event = EventFactory()
         event.tags.add(used_tag)
 
-        response = api_client.get(reverse("event-tag-list"))  # adjust to actual route name
+        response = api_client.get(reverse("event-tag-list"))
 
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1

--- a/events/tests/test_apis.py
+++ b/events/tests/test_apis.py
@@ -40,8 +40,8 @@ class TestEventsAPI:
         assert response.data["title"] == video_asset.title
         assert response.data["status"] == VideoAsset.VideoStatus.READY
 
-    def test_playlist_list(self, api_client):
-        """ Test that only playlists linked to events are returned """
+    def test_list_playlists(self, api_client):
+        """ Test listing all playlists """
         linked_playlist = PlaylistFactory(name="Used Playlist")
         unused_playlist = PlaylistFactory(name="Unused Playlist")
 
@@ -57,8 +57,8 @@ class TestEventsAPI:
         assert len(response.data) == 1
         assert response.data[0]["name"] == "Used Playlist"
 
-    def test_event_tag_list(self, api_client):
-        """ Test that only tags linked to events are returned """
+    def test_list_tags(self, api_client):
+        """ Test listing all tags """
         used_tag = TagFactory(name="Used Tag")
         unused_tag = TagFactory(name="Unused Tag")
 

--- a/events/tests/test_apis.py
+++ b/events/tests/test_apis.py
@@ -40,19 +40,33 @@ class TestEventsAPI:
         assert response.data["title"] == video_asset.title
         assert response.data["status"] == VideoAsset.VideoStatus.READY
 
-    def test_list_playlists(self, api_client):
-        """ Test listing all playlists """
-        PlaylistFactory.create_batch(2)
-        response = api_client.get(reverse("playlist-list"))
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 2
+    def test_event_playlist_list(self, api_client):
+        """ Test that only playlists linked to events are returned """
+        linked_playlist = PlaylistFactory(name="Used Playlist")
+        unused_playlist = PlaylistFactory(name="Unused Playlist")
 
-    def test_list_tags(self, api_client):
-        """ Test listing all tags """
-        TagFactory.create_batch(4)
-        response = api_client.get(reverse("tag-list"))
+        event = EventFactory()
+        event.playlists.add(linked_playlist)
+
+        response = api_client.get(reverse("event-playlist-list"))
+
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 4
+        assert len(response.data) == 1
+        assert response.data[0]["name"] == "Used Playlist"
+
+    def test_event_tag_list(self, api_client):
+        """ Test that only tags linked to events are returned """
+        used_tag = TagFactory(name="Used Tag")
+        unused_tag = TagFactory(name="Unused Tag")
+
+        event = EventFactory()
+        event.tags.add(used_tag)
+
+        response = api_client.get(reverse("event-tag-list"))  # adjust to actual route name
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["name"] == "Used Tag"
 
     def test_event_recommendations(self, api_client):
         """ Test retrieving event recommendations """

--- a/events/tests/test_apis.py
+++ b/events/tests/test_apis.py
@@ -40,7 +40,7 @@ class TestEventsAPI:
         assert response.data["title"] == video_asset.title
         assert response.data["status"] == VideoAsset.VideoStatus.READY
 
-    def test_event_playlist_list(self, api_client):
+    def test_playlist_list(self, api_client):
         """ Test that only playlists linked to events are returned """
         linked_playlist = PlaylistFactory(name="Used Playlist")
         unused_playlist = PlaylistFactory(name="Unused Playlist")
@@ -48,8 +48,11 @@ class TestEventsAPI:
         event = EventFactory()
         event.playlists.add(linked_playlist)
 
-        response = api_client.get(reverse("event-playlist-list"))
+        response = api_client.get(reverse("playlist-list"))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 2
 
+        response = api_client.get(reverse("playlist-list"), {'linked_to_events': True})
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
         assert response.data[0]["name"] == "Used Playlist"
@@ -62,8 +65,11 @@ class TestEventsAPI:
         event = EventFactory()
         event.tags.add(used_tag)
 
-        response = api_client.get(reverse("event-tag-list"))
+        response = api_client.get(reverse("tag-list"))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 2
 
+        response = api_client.get(reverse("tag-list"), {'linked_to_events': True})
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
         assert response.data[0]["name"] == "Used Tag"

--- a/events/v1/filters.py
+++ b/events/v1/filters.py
@@ -2,7 +2,7 @@ import django_filters
 
 from django.db.models import Q
 
-from events.models import Event
+from events.models import Event, Playlist, Tag
 
 
 class EventFilter(django_filters.rest_framework.FilterSet):
@@ -38,3 +38,35 @@ class EventFilter(django_filters.rest_framework.FilterSet):
         return queryset.filter(
             playlists__name=value
         )
+
+
+class TagFilter(django_filters.rest_framework.FilterSet):
+    """ Filter for the Tag model """
+
+    linked_to_events = django_filters.BooleanFilter(method='filter_linked_to_events')
+
+    class Meta:
+        model = Tag
+        fields = ['linked_to_events']
+
+    def filter_linked_to_events(self, queryset, _, value):
+        """ Filter the queryset based on the linked_to_events value """
+        if value:
+            return queryset.filter(events__isnull=False).distinct()
+        return queryset
+
+
+class PlaylistFilter(django_filters.rest_framework.FilterSet):
+    """ Filter for the Playlist model """
+
+    linked_to_events = django_filters.BooleanFilter(method='filter_linked_to_events')
+
+    class Meta:
+        model = Playlist
+        fields = ['linked_to_events']
+
+    def filter_linked_to_events(self, queryset, _, value):
+        """ Filter the queryset based on the linked_to_events value """
+        if value:
+            return queryset.filter(events__isnull=False).distinct()
+        return queryset

--- a/events/v1/urls.py
+++ b/events/v1/urls.py
@@ -1,6 +1,12 @@
 from django.urls import path
 
-from .views import EventRecommendationsView, EventsListView, EventPlaylistListView, EventTagListView, VideoAssetDetailView
+from .views import (
+    EventPlaylistListView,
+    EventRecommendationsView,
+    EventsListView,
+    EventTagListView,
+    VideoAssetDetailView,
+)
 
 urlpatterns = [
     path('all/', EventsListView.as_view(), name='events-list'),

--- a/events/v1/urls.py
+++ b/events/v1/urls.py
@@ -1,17 +1,17 @@
 from django.urls import path
 
-from .views import (
-    EventPlaylistListView,
+from events.v1.views import (
     EventRecommendationsView,
     EventsListView,
-    EventTagListView,
+    PlaylistListView,
+    TagListView,
     VideoAssetDetailView,
 )
 
 urlpatterns = [
     path('all/', EventsListView.as_view(), name='events-list'),
     path('videoasset/<int:pk>/', VideoAssetDetailView.as_view(), name='video-asset-detail'),
-    path('playlists/', EventPlaylistListView.as_view(), name='event-playlist-list'),
-    path('tags/', EventTagListView.as_view(), name='event-tag-list'),
+    path('playlists/', PlaylistListView.as_view(), name='playlist-list'),
+    path('tags/', TagListView.as_view(), name='tag-list'),
     path('recommendations/<event_id>/', EventRecommendationsView.as_view(), name='recommendation')
 ]

--- a/events/v1/urls.py
+++ b/events/v1/urls.py
@@ -1,11 +1,11 @@
 from django.urls import path
 
-from .views import EventRecommendationsView, EventsListView, PlaylistListView, TagListView, VideoAssetDetailView
+from .views import EventRecommendationsView, EventsListView, EventPlaylistListView, EventTagListView, VideoAssetDetailView
 
 urlpatterns = [
     path('all/', EventsListView.as_view(), name='events-list'),
     path('videoasset/<int:pk>/', VideoAssetDetailView.as_view(), name='video-asset-detail'),
-    path('playlists/', PlaylistListView.as_view(), name='playlist-list'),
-    path('tags/', TagListView.as_view(), name='tag-list'),
+    path('playlists/', EventPlaylistListView.as_view(), name='event-playlist-list'),
+    path('tags/', EventTagListView.as_view(), name='event-tag-list'),
     path('recommendations/<event_id>/', EventRecommendationsView.as_view(), name='recommendation')
 ]

--- a/events/v1/views.py
+++ b/events/v1/views.py
@@ -34,16 +34,16 @@ class VideoAssetDetailView(RetrieveAPIView):
         return obj
 
 
-class TagListView(ListAPIView):
-    """ View for listing all tags """
+class EventTagListView(ListAPIView):
+    """ View for listing tags hat are linked to events """
 
     queryset = Tag.objects.filter(events__isnull=False).distinct()
     serializer_class = TagListSerializer
     pagination_class = None
 
 
-class PlaylistListView(ListAPIView):
-    """ View for listing all playlists """
+class EventPlaylistListView(ListAPIView):
+    """ View for listing playlists that are linked to events """
 
     queryset = Playlist.objects.filter(events__isnull=False).distinct()
     serializer_class = PlaylistListSerializer

--- a/events/v1/views.py
+++ b/events/v1/views.py
@@ -35,7 +35,7 @@ class VideoAssetDetailView(RetrieveAPIView):
 
 
 class TagListView(ListAPIView):
-    """ View for listing the tags """
+    """ View for listing all tags """
 
     queryset = Tag.objects.all()
     serializer_class = TagListSerializer
@@ -44,7 +44,7 @@ class TagListView(ListAPIView):
 
 
 class PlaylistListView(ListAPIView):
-    """ View for listing the playlists """
+    """ View for listing all playlists """
 
     queryset = Playlist.objects.all()
     serializer_class = PlaylistListSerializer

--- a/events/v1/views.py
+++ b/events/v1/views.py
@@ -6,7 +6,7 @@ from rest_framework.views import APIView
 from django.shortcuts import get_object_or_404
 
 from events.models import Event, Playlist, Tag, VideoAsset
-from events.v1.filters import EventFilter
+from events.v1.filters import EventFilter, PlaylistFilter, TagFilter
 from events.v1.pagination import CustomPageNumberPagination
 from events.v1.serializers import EventSerializer, PlaylistListSerializer, TagListSerializer, VideoAssetSerializer
 from events.v1.utils import get_similar_events
@@ -34,20 +34,22 @@ class VideoAssetDetailView(RetrieveAPIView):
         return obj
 
 
-class EventTagListView(ListAPIView):
-    """ View for listing tags hat are linked to events """
+class TagListView(ListAPIView):
+    """ View for listing the tags """
 
-    queryset = Tag.objects.filter(events__isnull=False).distinct()
+    queryset = Tag.objects.all()
     serializer_class = TagListSerializer
     pagination_class = None
+    filterset_class = TagFilter
 
 
-class EventPlaylistListView(ListAPIView):
-    """ View for listing playlists that are linked to events """
+class PlaylistListView(ListAPIView):
+    """ View for listing the playlists """
 
-    queryset = Playlist.objects.filter(events__isnull=False).distinct()
+    queryset = Playlist.objects.all()
     serializer_class = PlaylistListSerializer
     pagination_class = None
+    filterset_class = PlaylistFilter
 
 
 class EventRecommendationsView(APIView):

--- a/events/v1/views.py
+++ b/events/v1/views.py
@@ -37,7 +37,7 @@ class VideoAssetDetailView(RetrieveAPIView):
 class TagListView(ListAPIView):
     """ View for listing all tags """
 
-    queryset = Tag.objects.all()
+    queryset = Tag.objects.filter(events__isnull=False).distinct()
     serializer_class = TagListSerializer
     pagination_class = None
 
@@ -45,7 +45,7 @@ class TagListView(ListAPIView):
 class PlaylistListView(ListAPIView):
     """ View for listing all playlists """
 
-    queryset = Playlist.objects.all()
+    queryset = Playlist.objects.filter(events__isnull=False).distinct()
     serializer_class = PlaylistListSerializer
     pagination_class = None
 


### PR DESCRIPTION
## Description

This PR introduces filtering functionality for the `Tag` and `Playlist` models in the events app, allowing API consumers to filter tags and playlists based on whether they are linked to any events.

- Added `PlaylistFilter` and `TagFilter` classes in `events/v1/filters.py`:
  - Both filters provide a `linked_to_events` boolean filter, which returns only those tags/playlists linked to at least one event if set to `true`.

- Integrated the new filters into the `/events/playlists/ `and `/events/tags/ `APIs:


Link to the associated Taiga ticket: https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/182
