### PR TITLE
Filter /events/all API to Return Only Events with Linked VideoAsset

### DIFF
--- a/events/tests/test_apis.py
+++ b/events/tests/test_apis.py
@@ -27,10 +27,33 @@ class TestEventsAPI:
 
     def test_list_events(self, api_client):
         """ Test listing all events """
-        EventFactory.create_batch(3)
+        events = [EventFactory() for _ in range(3)]
+        for event in events:
+            VideoAssetFactory(event=event)
         response = api_client.get(reverse("events-list"))
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data["results"]) == 3
+
+    def test_list_events_with_and_without_videoasset(self, api_client):
+        """ Test that /events/all returns only events with linked VideoAssets """
+
+        # Create 2 events without video assets
+        EventFactory.create_batch(2)
+
+        # Create 3 events and attach video assets
+        events_with_video = [EventFactory() for _ in range(3)]
+        for event in events_with_video:
+            VideoAssetFactory(event=event)
+
+        response = api_client.get(reverse("events-list"))  # Replace with actual route name if different
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]) == 3
+
+        returned_ids = {e["id"] for e in response.data["results"]}
+        expected_ids = {e.id for e in events_with_video}
+
+        assert returned_ids == expected_ids, "Only events with VideoAssets should be returned"
 
     def test_video_asset_detail(self, api_client):
         """ Test retrieving a video asset detail """

--- a/events/tests/test_filters.py
+++ b/events/tests/test_filters.py
@@ -1,16 +1,12 @@
 import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
-from events.factories import (
-    EventFactory,
-    PlaylistFactory,
-    TagFactory,
-    UserFactory,
-    VideoAssetFactory
-)
+# pylint: disable=duplicate-code
+from events.factories import EventFactory, PlaylistFactory, TagFactory, UserFactory, VideoAssetFactory
 
 User = get_user_model()
 

--- a/events/tests/test_filters.py
+++ b/events/tests/test_filters.py
@@ -1,11 +1,16 @@
 import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
-
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
-from events.factories import EventFactory, PlaylistFactory, TagFactory, UserFactory
+from events.factories import (
+    EventFactory,
+    PlaylistFactory,
+    TagFactory,
+    UserFactory,
+    VideoAssetFactory
+)
 
 User = get_user_model()
 
@@ -21,10 +26,15 @@ class TestEventFilters:
         client.force_authenticate(user=user)
         return client
 
+    def _create_event_with_video(self, **kwargs):
+        event = EventFactory(**kwargs)
+        VideoAssetFactory(event=event)
+        return event
+
     def test_events_search_filter_by_title(self, api_client):
         """ Test filtering events by search term in title """
-        EventFactory(title="Python Conference 2024")
-        EventFactory(title="Machine Learning Summit")
+        self._create_event_with_video(title="Python Conference 2024")
+        self._create_event_with_video(title="Machine Learning Summit")
 
         response = api_client.get(reverse("events-list"), {'search': 'Python'})
 
@@ -34,8 +44,8 @@ class TestEventFilters:
 
     def test_events_search_filter_by_description(self, api_client):
         """ Test filtering events by search term in description """
-        EventFactory(title="Tech Event 1", description="Python programming techniques")
-        EventFactory(title="Tech Event 2", description="Machine learning advancements")
+        self._create_event_with_video(title="Tech Event 1", description="Python programming techniques")
+        self._create_event_with_video(title="Tech Event 2", description="Machine learning advancements")
 
         response = api_client.get(reverse("events-list"), {'search': 'programming'})
 
@@ -48,8 +58,8 @@ class TestEventFilters:
         creator1 = UserFactory(first_name="John", last_name="Doe")
         creator2 = UserFactory(first_name="Jane", last_name="Smith")
 
-        EventFactory(title="Event 1", creator=creator1)
-        EventFactory(title="Event 2", creator=creator2)
+        self._create_event_with_video(title="Event 1", creator=creator1)
+        self._create_event_with_video(title="Event 2", creator=creator2)
 
         response = api_client.get(reverse("events-list"), {'search': 'John'})
 
@@ -62,10 +72,10 @@ class TestEventFilters:
         python_tag = TagFactory(name="Python")
         ml_tag = TagFactory(name="Machine Learning")
 
-        event1 = EventFactory(title="Python Workshop")
+        event1 = self._create_event_with_video(title="Python Workshop")
         event1.tags.add(python_tag)
 
-        event2 = EventFactory(title="ML Conference")
+        event2 = self._create_event_with_video(title="ML Conference")
         event2.tags.add(ml_tag)
 
         response = api_client.get(reverse("events-list"), {'tag': 'Python'})
@@ -79,10 +89,10 @@ class TestEventFilters:
         tech_playlist = PlaylistFactory(name="Tech Talks")
         data_science_playlist = PlaylistFactory(name="Data Science")
 
-        event1 = EventFactory(title="Python Event")
+        event1 = self._create_event_with_video(title="Python Event")
         event1.playlists.add(tech_playlist)
 
-        event2 = EventFactory(title="Data Science Workshop")
+        event2 = self._create_event_with_video(title="Data Science Workshop")
         event2.playlists.add(data_science_playlist)
 
         response = api_client.get(reverse("events-list"), {'playlist': 'Tech Talks'})
@@ -93,9 +103,9 @@ class TestEventFilters:
 
     def test_events_ordering_by_event_type(self, api_client):
         """ Test ordering events by event type """
-        EventFactory(title="Conference A", event_type="conference")
-        EventFactory(title="Webinar B", event_type="webinar")
-        EventFactory(title="Workshop C", event_type="workshop")
+        self._create_event_with_video(title="Conference A", event_type="conference")
+        self._create_event_with_video(title="Webinar B", event_type="webinar")
+        self._create_event_with_video(title="Workshop C", event_type="workshop")
 
         # Order events by event type ascending
         response = api_client.get(reverse("events-list"), {'ordering': 'event_type'})
@@ -113,9 +123,9 @@ class TestEventFilters:
 
     def test_events_ordering_by_featured(self, api_client):
         """ Test ordering events by featured status """
-        EventFactory(title="Featured Event 1", is_featured=True)
-        EventFactory(title="Non-Featured Event", is_featured=False)
-        EventFactory(title="Featured Event 2", is_featured=True)
+        self._create_event_with_video(title="Featured Event 1", is_featured=True)
+        self._create_event_with_video(title="Non-Featured Event", is_featured=False)
+        self._create_event_with_video(title="Featured Event 2", is_featured=True)
 
         # Order events by featured status ascending
         response = api_client.get(reverse("events-list"), {'ordering': 'is_featured'})

--- a/events/v1/views.py
+++ b/events/v1/views.py
@@ -15,7 +15,7 @@ from events.v1.utils import get_similar_events
 class EventsListView(ListAPIView):
     """ View for listing the events """
 
-    queryset = Event.objects.all().order_by("-status")
+    queryset = Event.objects.filter(videos__isnull=False).order_by("-status")
     serializer_class = EventSerializer
     pagination_class = CustomPageNumberPagination
     filterset_class = EventFilter


### PR DESCRIPTION
## Description

- Updated the` /events/all` API endpoint to return only events that are associated with a `VideoAsset`. 
- Updated `test_list_events` and all `TestEventFilters` tests to ensure that every event under test has an associated VideoAsset.
- Added a new test to assert that events without VideoAsset are correctly excluded from the API response.

Link to the associated Taiga ticket: https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/184