### PR TITLE
194 | Retrieve VideoAsset and Recommendations using slug instead of id

### DIFF
--- a/events/factories.py
+++ b/events/factories.py
@@ -3,6 +3,7 @@ from faker import Faker
 
 from django.contrib.auth import get_user_model
 from django.utils import timezone
+from django.utils.text import slugify
 
 from events.models import Event, EventPresenter, Playlist, Tag, VideoAsset
 
@@ -28,6 +29,7 @@ class EventFactory(factory.django.DjangoModelFactory):
 
     creator = factory.SubFactory(UserFactory)
     title = factory.Faker("sentence", nb_words=4)
+    slug = factory.LazyAttribute(lambda obj: slugify(obj.title))
     description = factory.Faker("paragraph")
     event_time = factory.LazyFunction(lambda: timezone.now() + timezone.timedelta(days=30))
     event_type = Event.EventType.SESSION

--- a/events/tests/test_apis.py
+++ b/events/tests/test_apis.py
@@ -58,7 +58,7 @@ class TestEventsAPI:
     def test_video_asset_detail(self, api_client):
         """ Test retrieving a video asset detail """
         video_asset = VideoAssetFactory()
-        response = api_client.get(reverse("video-asset-detail", args=[video_asset.event.id]))
+        response = api_client.get(reverse("video-asset-detail", args=[video_asset.event.slug]))
         assert response.status_code == status.HTTP_200_OK
         assert response.data["title"] == video_asset.title
         assert response.data["status"] == VideoAsset.VideoStatus.READY
@@ -120,7 +120,7 @@ class TestEventsAPI:
             unrelated_event.playlists.add(other_playlist)
             unrelated_event.save()
 
-        response = api_client.get(reverse("recommendation", args=[event.id]))
+        response = api_client.get(reverse("recommendation", args=[event.slug]))
         assert response.status_code == status.HTTP_200_OK
 
         returned_ids = {e["id"] for e in response.data}

--- a/events/v1/urls.py
+++ b/events/v1/urls.py
@@ -10,8 +10,8 @@ from events.v1.views import (
 
 urlpatterns = [
     path('all/', EventsListView.as_view(), name='events-list'),
-    path('videoasset/<int:pk>/', VideoAssetDetailView.as_view(), name='video-asset-detail'),
+    path('videoasset/<slug:event_slug>/', VideoAssetDetailView.as_view(), name='video-asset-detail'),
     path('playlists/', PlaylistListView.as_view(), name='playlist-list'),
     path('tags/', TagListView.as_view(), name='tag-list'),
-    path('recommendations/<event_id>/', EventRecommendationsView.as_view(), name='recommendation')
+    path('recommendations/<slug:event_slug>/', EventRecommendationsView.as_view(), name='recommendation')
 ]

--- a/events/v1/utils.py
+++ b/events/v1/utils.py
@@ -4,12 +4,12 @@ from django.shortcuts import get_object_or_404
 from events.models import Event
 
 
-def get_similar_events(event_id: int) -> list[Event]:
+def get_similar_events(event_slug: str) -> list[Event]:
     """
     Retrieve similar events based on playlists, presenters, and tags.
     Excludes the current event and returns a maximum of 5 latest events.
     """
-    event = get_object_or_404(Event, id=event_id)
+    event = get_object_or_404(Event, slug=event_slug)
     exclude_current = ~Q(id=event.id)
     similarity_query = Q()
 

--- a/events/v1/views.py
+++ b/events/v1/views.py
@@ -29,7 +29,7 @@ class VideoAssetDetailView(RetrieveAPIView):
     def get_object(self):
         obj = get_object_or_404(
             VideoAsset.objects.select_related('event__creator').prefetch_related('event__tags', 'event__playlists'),
-            event_id=self.kwargs["pk"]
+            event__slug=self.kwargs["event_slug"]
             )
         return obj
 
@@ -55,8 +55,8 @@ class PlaylistListView(ListAPIView):
 class EventRecommendationsView(APIView):
     """ View for listing similar events """
 
-    def get(self, request, event_id, *args, **kwargs):
+    def get(self, request, event_slug, *args, **kwargs):
         """ Get similar events based on the same playlist, presenter or tags """
-        similar_events = get_similar_events(event_id)
+        similar_events = get_similar_events(event_slug)
         serializer = EventSerializer(similar_events, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Description

- Updated API endpoints and views to use the `Event.slug` field in place of the `Event.id` for improved URL readability

Link to the associated Taiga ticket: https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/194

## Considerations

- Ensure that the changes are merged only after receiving at least two reviews.
- Take performance issues into account.
- Verify that database migrations are backwards-compatible.

## Post-review

Combine commits into distinct sets of changes.
