### PR TITLE
228 | Allow filtering events by presenter full name

### DIFF
--- a/events/tests/test_filters.py
+++ b/events/tests/test_filters.py
@@ -194,6 +194,12 @@ class TestEventFilters:
         assert len(response.data["results"]) == 1
         assert response.data["results"][0]["title"] == "Python Workshop"
 
+        response = api_client.get(reverse("events-list"), {'search': 'Bob Wilson'})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]) == 1
+        assert response.data["results"][0]["title"] == "Data Science Talk"
+
     def test_events_search_multiple_presenters(self, api_client):
         """ Test event with multiple presenters """
         presenter1 = UserFactory(first_name="Alice", last_name="Johnson")

--- a/events/v1/filters.py
+++ b/events/v1/filters.py
@@ -1,7 +1,8 @@
 import django_filters
 
 from django.contrib.postgres.search import TrigramSimilarity
-from django.db.models import Exists, OuterRef, Q
+from django.db.models import Exists, OuterRef, Q, Value
+from django.db.models.functions import Concat
 
 from events.models import Event, EventPresenter, Playlist, Tag
 
@@ -49,9 +50,10 @@ class EventFilter(django_filters.rest_framework.FilterSet):
 
         presenter_match = EventPresenter.objects.filter(
             event=OuterRef('pk')
+        ).annotate(
+            full_name=Concat('user__first_name', Value(' '), 'user__last_name')
         ).filter(
-            Q(user__first_name__icontains=search_term) |
-            Q(user__last_name__icontains=search_term)
+            full_name__icontains=search_term
         )
 
         queryset = queryset.annotate(


### PR DESCRIPTION
## Description

The system concatenates presenter first and last names, then performs a case-insensitive partial match against the search term. Events are displayed only if they have at least one presenter matching the query.

Link to the associated Taiga ticket: https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/228

## Considerations

- Ensure that the changes are merged only after receiving at least two reviews.
- Take performance issues into account.
- Verify that database migrations are backwards-compatible.

## Post-review

Combine commits into distinct sets of changes.
