### PR TITLE
248 | Only show published events in recommended events

### DIFF
--- a/events/v1/utils.py
+++ b/events/v1/utils.py
@@ -12,6 +12,7 @@ def get_similar_events(event_slug: str) -> list[Event]:
     event = get_object_or_404(Event, slug=event_slug)
     exclude_current = ~Q(id=event.id)
     similarity_query = Q()
+    published_filter = Q(status=Event.EventStatus.PUBLISHED)
 
     if event.playlists.exists():
         similarity_query |= Q(playlists__in=event.playlists.all())
@@ -20,8 +21,8 @@ def get_similar_events(event_slug: str) -> list[Event]:
     if event.tags.exists():
         similarity_query |= Q(tags__in=event.tags.all())
 
-    similar_events = Event.objects.filter(exclude_current & similarity_query).distinct()
-    latest_events = Event.objects.filter(exclude_current).order_by('-event_time')[:5]
+    similar_events = Event.objects.filter(exclude_current & similarity_query & published_filter).distinct()
+    latest_events = Event.objects.filter(exclude_current & published_filter).order_by('-event_time')[:5]
 
     combined_events = list(similar_events) + list(latest_events)
     unique_events = {event.id: event for event in combined_events}.values()


### PR DESCRIPTION
## Description

This PR modifies the get_similar_events function to only return events that have a PUBLISHED status.

The previous implementation did not check for the event's status, which could lead to draft or archived content being displayed as a "related event" on the public site.

Link to the associated Taiga ticket: https://projects.arbisoft.com/project/arbisoft-sessions-portal-20/us/248

## Considerations

- Ensure that the changes are merged only after receiving at least two reviews.
- Take performance issues into account.
- Verify that database migrations are backwards-compatible.

## Post-review

Combine commits into distinct sets of changes.
